### PR TITLE
Update External Auth docs

### DIFF
--- a/help/server/serverconfig.markdown
+++ b/help/server/serverconfig.markdown
@@ -538,7 +538,7 @@ Default value: empty
 
 Type: string
 
-The key of the external authentication server. Only has an effect if you to provide [a URL for authentication](#external-authentication-url) on startup and [enable external authentication](#external-authentication-enabled).
+The key of the external authentication server. If you're generating a keypair, this would use the public key. Only has an effect if you to provide [a URL for authentication](#external-authentication-url) on startup and [enable external authentication](#external-authentication-enabled).
 
 If you want to use drawpile.net's authentication, use the key `9eJ2tMJlqgSqHOIK/GI/qzS14WqIxHeB1Im5Hs/CCCk=`
 

--- a/help/tech/extauth.markdown
+++ b/help/tech/extauth.markdown
@@ -88,19 +88,19 @@ If the token is valid, the login process is complete.
 ## Authentication token
 
 The authentication token format is heavily inspired by the JSON Web Token standard.
-The format is:
+There are two distinct key formats. This is the regular one:
 
-    <version>.<payload>.<signature>
+    1.<payload>.<signature>
 
-where `version` is the token format version number (`1`),
-`payload` is a base64 encoded JSON object and
-`signature` is a base64 encoded Ed25519 signature of `<version>.<payload>`
+where `payload` is a base64 encoded JSON object and
+`signature` is a base64 encoded Ed25519 signature of `1.<payload>`, signed by the private key of the external-auth keypair.
 
 When an avatar image is requested (and returned,) version 2 token format is used:
 
     2.<payload>.<avatar>.<signature>
 
-The `avatar` is a base64 encoded image file.
+where `avatar` is a base64 encoded image file and
+`signature` is a base64 encoded Ed25519 signature of `2.<payload>.<avatar>`, signed by the private key of the external-auth keypair.
 
 The payload contains:
 


### PR DESCRIPTION
I tried to implement an External-Auth server and the existing documentation seems to be outdated and inaccurate.

Notable changes:
- Ensure that no server admin, when generating their own ext-auth keypair, gives the private key to the server
- Clarify authentication token formats, and that version 2 takes in `<avatar>` as part of its signature